### PR TITLE
Restore missing typeguards

### DIFF
--- a/events/commandInteraction.js
+++ b/events/commandInteraction.js
@@ -1,10 +1,10 @@
-const { InteractionType, PermissionsBitField } = require("discord.js");
+const { PermissionsBitField } = require("discord.js");
 
 // Command interaction
 module.exports = {
 	name: "interactionCreate",
 	async execute(interaction, client) {
-		if (interaction.type !== InteractionType.ApplicationCommand) return;
+		if (!interaction.isCommand()) return;
 
 		if (!interaction.channel.permissionsFor(interaction.user).has(PermissionsBitField.Flags.UseApplicationCommands))
 			return await interaction.reply({

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -1,4 +1,3 @@
-const { InteractionType } = require("discord.js");
 const { sendLog } = require("../utils/sendLog.js");
 
 module.exports = {
@@ -7,7 +6,7 @@ module.exports = {
 		await sendLog({}, interaction, client);
 		console.log(
 			`${interaction.user.tag} in #${interaction.channel.name} triggered an interaction named "${
-				interaction.type === InteractionType.ApplicationCommand ? interaction.commandName : interaction.customId
+				interaction.isCommand() ? interaction.commandName : interaction.customId
 			}".`
 		);
 	},

--- a/events/modalSubmit.js
+++ b/events/modalSubmit.js
@@ -1,10 +1,8 @@
-const { InteractionType } = require("discord.js");
-
 // Modal Submission for commands
 module.exports = {
 	name: "interactionCreate",
 	async execute(interaction, client) {
-		if (interaction.type !== InteractionType.ModalSubmit) return;
+		if (!interaction.isModalSubmit()) return;
 
 		const modal = client.modals.get(interaction.customId);
 

--- a/utils/sendLog.js
+++ b/utils/sendLog.js
@@ -24,10 +24,10 @@ module.exports = {
 				)
 				.setColor(isAdded ? Colors.Orange : Colors.Purple);
 		} else if (interaction) {
-			if (interaction.type !== 2 && interaction.type !== 3) return;
-			if (!logParameters[interaction.type === 2 ? "command" : "button"]) return;
+			if (!interaction.isCommand() && !interaction.isButton()) return;
+			if (!logParameters[interaction.isCommand() ? "command" : "button"]) return;
 
-			const isCommand = interaction.type === 2;
+			const isCommand = interaction.isCommand();
 			const interactionName = interaction.commandName || interaction.customId;
 			const subCommandName = interaction.options?._subcommand;
 


### PR DESCRIPTION
Version [14.1](https://github.com/discordjs/discord.js/pull/8328) of `discord.js` restores the the following typeguard methods:
- `BaseInteraction#isCommand()`
- `BaseInteraction#isModalSubmit()`